### PR TITLE
Fix bug that was causing errors to be thrown on 200 OK responses

### DIFF
--- a/pynder/api.py
+++ b/pynder/api.py
@@ -28,7 +28,7 @@ class TinderAPI(object):
             raise errors.InitializationError
 
         result = self._session.get(self._url(url)).json()
-        if ('status' in result) and result['status'] == 200:
+        if ('status' in result) and result['status'] != 200:
             raise errors.RequestError(result['status'])
         return result
 


### PR DESCRIPTION
It's worth noting that 200 is not the *only* kind of success response, but for now I'm not aware of any others the Tinder API returns.