### PR TITLE
Handle no nearby users gracefully

### DIFF
--- a/pynder/session.py
+++ b/pynder/session.py
@@ -14,7 +14,9 @@ class Session(object):
         self.profile = models.Profile(self._api.profile(), self)
 
     def nearby_users(self):
-        return [models.Hopeful(u, self) for u in self._api.recs()['results']]
+        response = self._api.recs()
+        users = response['results'] if 'results' in response else []
+        return [models.Hopeful(u, self) for u in users]
 
     def update_location(self, latitude, longitude):
         return self._api.ping(latitude, longitude)


### PR DESCRIPTION
I've seen a response of the `{u"message": u"recs timeout"}` from `self._api.recs()`. Currently we'll get a KeyError when we try to look up 'results'. This patch handles that case gracefully and just returns an empty list.