### PR TITLE
Added basic Tinder Social capabilities, start #73.

### DIFF
--- a/examples/tinder_social_examples.py
+++ b/examples/tinder_social_examples.py
@@ -1,0 +1,25 @@
+import pynder
+
+FBID = "YOUR_FB_ID"
+FBTOKEN= "YOUR_FB_TOKEN"
+
+session = pynder.Session(FBID, FBTOKEN)
+friends = session.get_fb_friends()
+
+# Print the names of all facebook friends using Tinder Social.
+print(", ".join([x.name for x in friends]))
+
+# Get the user_info of these facebook friends.
+user_info_objects = []
+for friend in friends:
+    user_info_objects.append(friend.get_tinder_information())
+
+# Print the bios.
+for user_info, friend in zip(user_info_objects, friends):
+    print("=" * 50)
+    # Use Friend.name, as user_info.name only contains first name.
+    print(friend.name)
+    print(friend.facebook_link)
+    print("-" * 50)
+    print(user_info.bio)
+    print("=" * 50)

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -91,3 +91,10 @@ class TinderAPI(object):
         if 'limit_exceeded' in result and result['limit_exceeded']:
             raise errors.RequestError("Superlike limit exceeded")
         return result
+
+    def fb_friends(self):
+        """
+        Requests records of all facebook friends using Tinder Social.
+        :return: object containing array of all friends who use Tinder Social.
+        """
+        return self._get("/group/friends")

--- a/pynder/models/__init__.py
+++ b/pynder/models/__init__.py
@@ -1,3 +1,4 @@
+from .friend import Friend  # NOQA
 from .me import Profile  # NOQA
 from .message import Message  # NOQA
 from .user import Hopeful, Match  # NOQA

--- a/pynder/models/friend.py
+++ b/pynder/models/friend.py
@@ -1,0 +1,50 @@
+import re
+from .user import User
+
+facebook_id_pattern = re.compile(u'\.com/(\d+?)/')
+
+
+class Friend(object):
+
+    def __init__(self, data, session):
+        """
+        Wrapper for Tinder Social profile - a link between the tinder and
+        facebook profile.
+        :param data: The JSON object returned by the Tinder API endpoint.
+        :type data: Object
+        :param session: The session used to request the profile.
+        :type session: Session
+        """
+        self._session = session
+        self._data = data
+        self.name = data['name']
+        self.user_id = data['user_id']
+        self.in_squad = data['in_squad']
+
+        # Extract facebook id.
+        try:
+            processed_files = data['photo'][0]['processedFiles']
+            facebook_graph_url = processed_files[0]['url']
+            self.facebook_id = re.\
+                search(facebook_id_pattern, facebook_graph_url).group(1)
+
+            # Create facebook profile link.
+            base_url = "https://www.facebook.com/{}"
+            self.facebook_link = base_url.format(self.facebook_id)
+
+        except Exception:
+            self.facebook_id = None
+            self.facebook_link = None
+
+    def get_tinder_information(self):
+        """
+        Makes request to get the friend's tinder profile information.
+        :return: Friend's information
+        :rtype: User
+        """
+        data = self._session._api.user_info(self._data['user_id'])
+        return User(data['results'], self._session)
+
+    def __repr__(self):
+        return u"{} (fb:{}, ti:{})".format(self.name, self.facebook_id,
+                                           self.user_id)

--- a/pynder/session.py
+++ b/pynder/session.py
@@ -31,6 +31,21 @@ class Session(object):
     def matches(self):
         return [models.Match(m, self) for m in self._api.matches()]
 
+    def get_fb_friends(self):
+        """
+        Returns array of all friends using Tinder Social.
+        :return: Array of friends.
+        :rtype: models.Friend[]
+        """
+        response = self._api.fb_friends()
+        friends = response['results']
+        ret = []
+
+        for f in friends:
+            ret.append(models.Friend(f, self))
+
+        return ret
+
     @property
     def likes_remaining(self):
         meta_dct = self._api.meta()


### PR DESCRIPTION
Add capability to

- Get list of facebook friends who are signed up to Tinder Social
- Create link to facebook profile of each of the friends
- Get Tinder profile information of each friend (i.e. information which is held by [models.User](https://github.com/charliewolf/pynder/blob/master/pynder/models/user.py#L8))

See `examples/tinder_social_examples.py` for an example.