### PR TITLE
To avoid KeyError: bio, set default value for user['bio']

### DIFF
--- a/pynder/models/user.py
+++ b/pynder/models/user.py
@@ -15,7 +15,7 @@ class User(object):
         self.id = data['_id']
 
         for field in SIMPLE_FIELDS:
-            setattr(self, field, data.get(field))
+            setattr(self, field, data.get(field, ''))
 
         self.photos_obj = [photo for photo in data['photos']]
         self.birth_date = dateutil.parser.parse(self.birth_date)


### PR DESCRIPTION
session._api.recs(limits=10) returns a list of user, but sometimes user does not have 'bio'. In case user does not have bio, user['bio'] should set to be ''.