### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Once your session is initialized you have the following methods / attributes:
 ::
 
     import pynder
-    session = pynder.Session(facebook_id, facebook_auth_token)
+    session = pynder.Session(facebook_id, facebook_auth_token) #kwargs
     session.matches() # get users you have already been matched with
     session.update_location(LAT, LON) # updates latitude and longitude for your profile
     session.profile  # your profile. If you update its attributes they will be updated on Tinder.


### PR DESCRIPTION
Users keep writing of 403 errors.  Using positional arguments for the pynder.Session argument instead of kwarg.