### PR TITLE
fix facebook auth for new v2 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist/
 *.egg-info
 pynder/tests/test.ini
 .coverage
-pynder/tests/test.ini

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.egg-info
 pynder/tests/test.ini
 .coverage
+pynder/tests/test.ini

--- a/examples/dump_conversation/dump.py
+++ b/examples/dump_conversation/dump.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 from argparse import ArgumentParser
 from codecs import open as copen
@@ -11,7 +12,7 @@ FB_TOKEN = FILL_THIS_IN
 
 
 def select_interactively(matches, name):
-    print "Found {n} matches with name: '{n}'".format(n=name)
+    print("Found {n} matches with name: '{n}'".format(n=name))
     N = len(matches)
     if N == 0:
         raise SystemExit("Please try with a different name")
@@ -20,12 +21,12 @@ def select_interactively(matches, name):
     selected = None
     while selected not in range(N):
         for i, m in enumerate(matches):
-            print "[{i}]\t{n}\t(ID #{id})".format(i=i, n=m.user.name, id=m.user.id)
-        print "Select one of the above listed matches"
+            print("[{i}]\t{n}\t(ID #{id})".format(i=i, n=m.user.name, id=m.user.id))
+        print("Select one of the above listed matches")
         try:
             return matches[int(raw_input("> "))]
         except Exception as e:
-            print e
+            print(e)
 
 
 if __name__ == "__main__":
@@ -36,7 +37,7 @@ if __name__ == "__main__":
     s = Session(facebook_id=ID, facebook_token=FB_TOKEN)
 
     matches = [m for m in s.matches() if m.user is not None and m.user.name == args.name]
-    match =  select_interactively(matches, args.name)
+    match = select_interactively(matches, args.name)
 
     output_filename = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_") + args.name + ".csv"
 
@@ -45,4 +46,4 @@ if __name__ == "__main__":
         for m in match.messages:
             w.writerow([m._data['sent_date'], m.sender, m.body])
 
-    print "Wrote:", output_filename
+    print("Wrote:", output_filename)

--- a/examples/like_5_users.py
+++ b/examples/like_5_users.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import itertools
 import pynder
 
@@ -7,4 +8,4 @@ FBID = "YOUR_FB_ID"
 session = pynder.Session(facebook_id=FBID, facebook_token=FBTOKEN)
 users = session.nearby_users()
 for user in itertools.islice(users, 5):
-    print user.like()
+    print(user.like())

--- a/examples/tinder_social_examples.py
+++ b/examples/tinder_social_examples.py
@@ -1,7 +1,7 @@
 import pynder
 
 FBID = "YOUR_FB_ID"
-FBTOKEN= "YOUR_FB_TOKEN"
+FBTOKEN = "YOUR_FB_TOKEN"
 
 session = pynder.Session(facebook_id=FBID, facebook_token=FBTOKEN)
 friends = session.get_fb_friends()

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -10,6 +10,7 @@ class TinderAPI(object):
         self._session = requests.Session()
         self._token = XAuthToken
         self._proxies = proxies
+        self._session.headers.update(constants.HEADERS)
         if XAuthToken is not None:
             self._session.headers.update({"X-Auth-Token": str(XAuthToken)})
 
@@ -23,8 +24,8 @@ class TinderAPI(object):
 
     def auth(self, facebook_token):
         data = {"token": facebook_token}
-        result = requests.post(
-            self._full_url('/v2/auth/login/facebook'), data=data, proxies=self._proxies).json()['data']
+        result = self._session.post(
+            self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies).json()['data']
         if 'api_token' not in result:
             raise errors.RequestError("Couldn't authenticate")
         self._token = result['api_token']

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -24,7 +24,7 @@ class TinderAPI(object):
     def auth(self, facebook_token):
         data = {"token": facebook_token}
         result = requests.post(
-            self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies).json()['data']
+            self._full_url('/v2/auth/login/facebook'), data=data, proxies=self._proxies).json()['data']
         if 'api_token' not in result:
             raise errors.RequestError("Couldn't authenticate")
         self._token = result['api_token']
@@ -35,7 +35,7 @@ class TinderAPI(object):
         if not hasattr(self, '_token'):
             raise errors.InitializationError
         result = self._session.request(method, self._full_url(
-            url), json=data, proxies=self._proxies)
+            url), data=data, proxies=self._proxies)
         while result.status_code == 429:
             blocker = threading.Event()
             blocker.wait(0.01)

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -24,7 +24,7 @@ class TinderAPI(object):
     def auth(self, facebook_token):
         data = {"token": facebook_token}
         result = requests.post(
-            self._full_url('/v2/auth/login/facebook'), data=data, proxies=self._proxies).json()['data']
+            self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies).json()['data']
         if 'api_token' not in result:
             raise errors.RequestError("Couldn't authenticate")
         self._token = result['api_token']
@@ -35,7 +35,7 @@ class TinderAPI(object):
         if not hasattr(self, '_token'):
             raise errors.InitializationError
         result = self._session.request(method, self._full_url(
-            url), data=data, proxies=self._proxies)
+            url), json=data, proxies=self._proxies)
         while result.status_code == 429:
             blocker = threading.Event()
             blocker.wait(0.01)

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -36,7 +36,7 @@ class TinderAPI(object):
         if not hasattr(self, '_token'):
             raise errors.InitializationError
         result = self._session.request(method, self._full_url(
-            url), data=data, proxies=self._proxies)
+            url), json=data, proxies=self._proxies)
         while result.status_code == 429:
             blocker = threading.Event()
             blocker.wait(0.01)

--- a/pynder/constants.py
+++ b/pynder/constants.py
@@ -3,18 +3,16 @@ from enum import Enum
 API_BASE = 'https://api.gotinder.com'
 CONTENT_BASE = 'https://content.gotinder.com'
 
-# No longer needed! 2019-04-29 ??????
-# USER_AGENT = 'Tinder Android Version 6.4.1'
+USER_AGENT = "Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)"
 
-# HEADERS = {
-#     "Content-Type": "application/json; charset=utf-8",
-#     "User-Agent": USER_AGENT,
-#     "Host": API_BASE,
-#     "os_version": "1935",
-#     "app-version": "371",
-#     "platform": "android",  # XXX with ios we run in an error
-#     "Accept-Encoding": "gzip"
-# }
+HEADERS = {
+    "Content-Type": "application/json",
+    "User-Agent": USER_AGENT,
+    "Host": API_BASE,
+    "app-version": "6.9.4",
+    "platform": "ios",  # XXX with ios we run in an error
+    "Accept-Encoding": "gzip"
+}
 
 GENDER_MAP = ("male", "female")
 

--- a/pynder/constants.py
+++ b/pynder/constants.py
@@ -3,17 +3,18 @@ from enum import Enum
 API_BASE = 'https://api.gotinder.com'
 CONTENT_BASE = 'https://content.gotinder.com'
 
-USER_AGENT = 'Tinder Android Version 6.4.1'
+# No longer needed! 2019-04-29 ??????
+# USER_AGENT = 'Tinder Android Version 6.4.1'
 
-HEADERS = {
-    "Content-Type": "application/json; charset=utf-8",
-    "User-Agent": USER_AGENT,
-    "Host": API_BASE,
-    "os_version": "1935",
-    "app-version": "371",
-    "platform": "android",  # XXX with ios we run in an error
-    "Accept-Encoding": "gzip"
-}
+# HEADERS = {
+#     "Content-Type": "application/json; charset=utf-8",
+#     "User-Agent": USER_AGENT,
+#     "Host": API_BASE,
+#     "os_version": "1935",
+#     "app-version": "371",
+#     "platform": "android",  # XXX with ios we run in an error
+#     "Accept-Encoding": "gzip"
+# }
 
 GENDER_MAP = ("male", "female")
 

--- a/pynder/models/friend.py
+++ b/pynder/models/friend.py
@@ -2,7 +2,7 @@ import re
 from pynder.models.user import User
 from pynder.models.base import Model
 
-facebook_id_pattern = re.compile(u'\.com/(\d+?)/')
+facebook_id_pattern = re.compile(u'\.com/(\d+?)/')  # noqa W605
 
 
 class Friend(Model):

--- a/pynder/session.py
+++ b/pynder/session.py
@@ -15,7 +15,7 @@ class Session(object):
         self._api = api.TinderAPI(XAuthToken, proxies)
         # perform authentication
         if XAuthToken is None:
-            self._api.auth(facebook_id, facebook_token)
+            self._api.auth(facebook_token)
 
     @cached_property
     def profile(self):

--- a/pynder/tests/test_session.py
+++ b/pynder/tests/test_session.py
@@ -17,16 +17,14 @@ class TestSession(unittest.TestCase):
     def setUp(self):
         pass
 
-    @my_vcr.use_cassette(filter_post_data_parameters=["facebook_id",
-                                                      "facebook_token"])
+    @my_vcr.use_cassette(filter_post_data_parameters=["facebook_token"])
     def test_login(self):
         auth = read_test_ini()
-        session = pynder.Session(facebook_id=auth["facebook_id"], facebook_token=auth["facebook_token"])
+        session = pynder.Session(facebook_token=auth["facebook_token"])
         self.assertEqual(session.profile.gender, "male")
 
-    @my_vcr.use_cassette(filter_post_data_parameters=["facebook_id",
-                                                      "facebook_token"])
+    @my_vcr.use_cassette(filter_post_data_parameters=["facebook_token"])
     def test_nearby_users_empty(self):
         auth = read_test_ini()
-        session = pynder.Session(facebook_token=auth["facebook_token"], facebook_id=auth["facebook_id"])
+        session = pynder.Session(facebook_token=auth["facebook_token"])
         self.assertEqual(len(list(session.nearby_users(limit=10))), 0)


### PR DESCRIPTION
Fixes facebook authentication for new v2 api.

Changes:
- new auth url
- json headers are no longer needed
- send post directly to auth url without headers

Test results:
```
Name                        Stmts   Miss  Cover
-----------------------------------------------
pynder/__init__.py              1      0   100%
pynder/api.py                  97     41    58%
pynder/constants.py            14      0   100%
pynder/errors.py               10      0   100%
pynder/models/__init__.py       5      0   100%
pynder/models/base.py           2      0   100%
pynder/models/friend.py        25     17    32%
pynder/models/me.py            69     24    65%
pynder/models/message.py       35     23    34%
pynder/models/user.py          99     62    37%
pynder/session.py              49     19    61%
-----------------------------------------------
TOTAL                         406    186    54%
----------------------------------------------------------------------
Ran 3 tests in 0.861s

OK
```

Closes:
https://github.com/charliewolf/pynder/issues/208