### PR TITLE
fix v2 auth for real this time???

### DIFF
--- a/examples/dump_conversation/dump.py
+++ b/examples/dump_conversation/dump.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 from argparse import ArgumentParser
 from codecs import open as copen
@@ -11,7 +12,7 @@ FB_TOKEN = FILL_THIS_IN
 
 
 def select_interactively(matches, name):
-    print "Found {n} matches with name: '{n}'".format(n=name)
+    print("Found {n} matches with name: '{n}'".format(n=name))
     N = len(matches)
     if N == 0:
         raise SystemExit("Please try with a different name")
@@ -20,12 +21,12 @@ def select_interactively(matches, name):
     selected = None
     while selected not in range(N):
         for i, m in enumerate(matches):
-            print "[{i}]\t{n}\t(ID #{id})".format(i=i, n=m.user.name, id=m.user.id)
-        print "Select one of the above listed matches"
+            print("[{i}]\t{n}\t(ID #{id})".format(i=i, n=m.user.name, id=m.user.id))
+        print("Select one of the above listed matches")
         try:
             return matches[int(raw_input("> "))]
         except Exception as e:
-            print e
+            print(e)
 
 
 if __name__ == "__main__":
@@ -45,4 +46,4 @@ if __name__ == "__main__":
         for m in match.messages:
             w.writerow([m._data['sent_date'], m.sender, m.body])
 
-    print "Wrote:", output_filename
+    print("Wrote:", output_filename)

--- a/examples/like_5_users.py
+++ b/examples/like_5_users.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import itertools
 import pynder
 
@@ -7,4 +8,4 @@ FBID = "YOUR_FB_ID"
 session = pynder.Session(facebook_id=FBID, facebook_token=FBTOKEN)
 users = session.nearby_users()
 for user in itertools.islice(users, 5):
-    print user.like()
+    print(user.like())

--- a/examples/tinder_social_examples.py
+++ b/examples/tinder_social_examples.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 import pynder
 
 FBID = "YOUR_FB_ID"
-FBTOKEN= "YOUR_FB_TOKEN"
+FBTOKEN = "YOUR_FB_TOKEN"
 
 session = pynder.Session(facebook_id=FBID, facebook_token=FBTOKEN)
 friends = session.get_fb_friends()

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -8,11 +8,12 @@ class TinderAPI(object):
 
     def __init__(self, XAuthToken=None, proxies=None):
         self._session = requests.Session()
-        self._session.headers.update(constants.HEADERS)
+        self._headers = constants.HEADERS
         self._token = XAuthToken
         self._proxies = proxies
         if XAuthToken is not None:
-            self._session.headers.update({"X-Auth-Token": str(XAuthToken)})
+            self._headers["X-Auth-Token"] = str(XAuthToken)
+            self._session.headers.update(self._headers)
 
     def _full_url(self, url):
         _url = url.lower()
@@ -23,16 +24,27 @@ class TinderAPI(object):
             return constants.API_BASE + url
 
     def auth(self, facebook_id, facebook_token):
-        data = {"facebook_id": str(facebook_id), "facebook_token": facebook_token}
-        result = self._session.post(
-            self._full_url('/auth'), json=data, proxies=self._proxies).json()
-        if 'token' not in result:
-            raise errors.RequestError("Couldn't authenticate")
-        self._token = result['token']
-        self._session.headers.update({"X-Auth-Token": str(result['token'])})
-        return result
+        data = {"token": facebook_token}
+        # result = self._session.post(
+        #     self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies)
+        result = requests.post(
+            self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies, headers=constants.HEADERS)
+        print(result)
+        if result.status_code == 200:
+            print(result.json())
+            json_result = result.json()
+            if 'api_token' not in json_result['data']:
+                raise errors.RequestError("Couldn't authenticate")
+            else:
+                self._token = json_result['data']['api_token']
+                self._headers["X-Auth-Token"] = str(self._token)
+                self._session.headers.update(self._headers)
+                return json_result['data']
+        else:
+            err = "Couldn't authenticate request status code: " + str(result.status_code)
+            raise errors.RequestError(err)
 
-    def _request(self, method, url, data={}):
+    def _request(self, method, url, data=None):
         if not hasattr(self, '_token'):
             raise errors.InitializationError
         result = self._session.request(method, self._full_url(

--- a/pynder/api.py
+++ b/pynder/api.py
@@ -25,13 +25,9 @@ class TinderAPI(object):
 
     def auth(self, facebook_id, facebook_token):
         data = {"token": facebook_token}
-        # result = self._session.post(
-        #     self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies)
         result = requests.post(
             self._full_url('/v2/auth/login/facebook'), json=data, proxies=self._proxies, headers=constants.HEADERS)
-        print(result)
         if result.status_code == 200:
-            print(result.json())
             json_result = result.json()
             if 'api_token' not in json_result['data']:
                 raise errors.RequestError("Couldn't authenticate")

--- a/pynder/constants.py
+++ b/pynder/constants.py
@@ -3,17 +3,6 @@ from enum import Enum
 API_BASE = 'https://api.gotinder.com'
 CONTENT_BASE = 'https://content.gotinder.com'
 
-# USER_AGENT = 'Tinder Android Version 6.4.1'
-
-# HEADERS = {
-#     "Content-Type": "application/json; charset=utf-8",
-#     "User-Agent": USER_AGENT,
-#     "Host": API_BASE,
-#     "os_version": "1935",
-#     "app-version": "371",
-#     "platform": "android",  # XXX with ios we run in an error
-#     "Accept-Encoding": "gzip"
-# }
 USER_AGENT = "Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)"
 
 HEADERS = {

--- a/pynder/constants.py
+++ b/pynder/constants.py
@@ -3,16 +3,25 @@ from enum import Enum
 API_BASE = 'https://api.gotinder.com'
 CONTENT_BASE = 'https://content.gotinder.com'
 
-USER_AGENT = 'Tinder Android Version 6.4.1'
+# USER_AGENT = 'Tinder Android Version 6.4.1'
+
+# HEADERS = {
+#     "Content-Type": "application/json; charset=utf-8",
+#     "User-Agent": USER_AGENT,
+#     "Host": API_BASE,
+#     "os_version": "1935",
+#     "app-version": "371",
+#     "platform": "android",  # XXX with ios we run in an error
+#     "Accept-Encoding": "gzip"
+# }
+USER_AGENT = "Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)"
 
 HEADERS = {
-    "Content-Type": "application/json; charset=utf-8",
-    "User-Agent": USER_AGENT,
-    "Host": API_BASE,
-    "os_version": "1935",
-    "app-version": "371",
-    "platform": "android",  # XXX with ios we run in an error
-    "Accept-Encoding": "gzip"
+    'app_version': '6.9.4',
+    'platform': 'ios',
+    "content-type": "application/json",
+    "User-agent": USER_AGENT,
+    "Accept": "application/json"
 }
 
 GENDER_MAP = ("male", "female")

--- a/pynder/models/friend.py
+++ b/pynder/models/friend.py
@@ -2,7 +2,7 @@ import re
 from pynder.models.user import User
 from pynder.models.base import Model
 
-facebook_id_pattern = re.compile(u'\.com/(\d+?)/')
+facebook_id_pattern = re.compile(u'\.com/(\d+?)/')  # noqa W605
 
 
 class Friend(Model):

--- a/pynder/tests/test_session.py
+++ b/pynder/tests/test_session.py
@@ -20,7 +20,8 @@ class TestSession(unittest.TestCase):
     @my_vcr.use_cassette(filter_post_data_parameters=["facebook_id",
                                                       "facebook_token",
                                                       "api_token",
-                                                      "token"])
+                                                      "token",
+                                                      "X-Auth-Token"])
     def test_login(self):
         auth = read_test_ini()
         session = pynder.Session(facebook_id=auth["facebook_id"], facebook_token=auth["facebook_token"])
@@ -29,7 +30,8 @@ class TestSession(unittest.TestCase):
     @my_vcr.use_cassette(filter_post_data_parameters=["facebook_id",
                                                       "facebook_token",
                                                       "api_token",
-                                                      "token"])
+                                                      "token",
+                                                      "X-Auth-Token"])
     def test_nearby_users_empty(self):
         auth = read_test_ini()
         session = pynder.Session(facebook_token=auth["facebook_token"], facebook_id=auth["facebook_id"])

--- a/pynder/tests/test_session.py
+++ b/pynder/tests/test_session.py
@@ -18,14 +18,18 @@ class TestSession(unittest.TestCase):
         pass
 
     @my_vcr.use_cassette(filter_post_data_parameters=["facebook_id",
-                                                      "facebook_token"])
+                                                      "facebook_token",
+                                                      "api_token",
+                                                      "token"])
     def test_login(self):
         auth = read_test_ini()
         session = pynder.Session(facebook_id=auth["facebook_id"], facebook_token=auth["facebook_token"])
         self.assertEqual(session.profile.gender, "male")
 
     @my_vcr.use_cassette(filter_post_data_parameters=["facebook_id",
-                                                      "facebook_token"])
+                                                      "facebook_token",
+                                                      "api_token",
+                                                      "token"])
     def test_nearby_users_empty(self):
         auth = read_test_ini()
         session = pynder.Session(facebook_token=auth["facebook_token"], facebook_id=auth["facebook_id"])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup, find_packages
 
 
-version = '0.0.13'
+version = '0.0.14'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as file:
     long_description = file.read()


### PR DESCRIPTION
Fixes facebook authentication for new v2 api.

Changes:
- new auth url
- initial auth is performed outside of session
- auth will now pass the requests code if failed
- updated headers
- headers are now stored in api
- session headers are only updated once
- New default in ```api._requsts```. Was ```data={}```, now is ```data=None``` (This was causing 403)
- Rolled version to ```0.0.14```; because why not

Test are passing on my computer...

Closes:
#208